### PR TITLE
Updates to make simplebackpack compatible with 1.19.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,18 @@
 org.gradle.jvmargs  = -Xmx2G
 
-minecraft_version=1.19.3-rc1
-yarn_mappings=1.19.3-rc1+build.2
-loader_version=0.14.11
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.2
+loader_version=0.14.21
 
 #Fabric api
-fabric_version=0.68.1+1.19.3
+fabric_version=0.86.1+1.19.4
 
 #Mod properties
-mod_version         = 1.4.7
+mod_version         = 1.4.8-1.19.4
 maven_group         = com.kwpugh
-archives_base_name  = SimpleBackpack_Fabric-1.19.3-rc1
+archives_base_name  = SimpleBackpack_Fabric-1.19.4
 
 # REI
-roughlyenoughitems = 9.1.503
-clothconfig = 9.0.92
-modmenu = 4.0.2
+roughlyenoughitems = 11.0.593
+clothconfig = 10.0.96
+modmenu = 6.3.1

--- a/src/main/java/com/kwpugh/simple_backpack/Backpack.java
+++ b/src/main/java/com/kwpugh/simple_backpack/Backpack.java
@@ -16,6 +16,7 @@ import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import me.shedaniel.autoconfig.serializer.PartitioningSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.item.Item;
+import net.minecraft.resource.featuretoggle.FeatureFlags;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.util.Identifier;
 import net.minecraft.registry.Registries;
@@ -47,9 +48,9 @@ public class Backpack implements ModInitializer
     @Override
     public void onInitialize()
     {
-        BACKPACK_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("backpack"), new ScreenHandlerType<>(BackpackScreenHandler::new, null));
-        VOID_PACK_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("void_pack"), new ScreenHandlerType<>(VoidpackScreenHandler::new, null));
-        PORTABLE_CRAFTING_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("portable_crafting"), new ScreenHandlerType<>(PortableCraftingScreenHandler::new, null));
+        BACKPACK_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("backpack"), new ScreenHandlerType<>(BackpackScreenHandler::new, FeatureFlags.VANILLA_FEATURES));
+        VOID_PACK_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("void_pack"), new ScreenHandlerType<>(VoidpackScreenHandler::new, FeatureFlags.VANILLA_FEATURES));
+        PORTABLE_CRAFTING_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("portable_crafting"), new ScreenHandlerType<>(PortableCraftingScreenHandler::new, FeatureFlags.VANILLA_FEATURES));
 
         Registry.register(Registries.ITEM, createID("backpack"), BACKPACK);
         Registry.register(Registries.ITEM, createID("void_pack"), VOID_PACK);

--- a/src/main/java/com/kwpugh/simple_backpack/Backpack.java
+++ b/src/main/java/com/kwpugh/simple_backpack/Backpack.java
@@ -26,10 +26,9 @@ import org.apache.logging.log4j.Logger;
 
 public class Backpack implements ModInitializer
 {
-    public static Logger LOGGER = LogManager.getLogger();
-
     public static final String MOD_ID = "simple_backpack";
     public static final String MOD_NAME = "SimpleBackpack";
+    public static Logger LOGGER = LogManager.getLogger(MOD_ID);
     public static final ModConfig CONFIG = AutoConfig.register(ModConfig.class, PartitioningSerializer.wrap(JanksonConfigSerializer::new)).getConfig();
 
     public static final Identifier ENDER_PACK_IDENTIFIER = new Identifier(MOD_ID, "ender_pack");
@@ -48,9 +47,9 @@ public class Backpack implements ModInitializer
     @Override
     public void onInitialize()
     {
-        BACKPACK_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("backpack"), new ScreenHandlerType<>(BackpackScreenHandler::new));
-        VOID_PACK_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("void_pack"), new ScreenHandlerType<>(VoidpackScreenHandler::new));
-        PORTABLE_CRAFTING_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("portable_crafting"), new ScreenHandlerType<>(PortableCraftingScreenHandler::new));
+        BACKPACK_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("backpack"), new ScreenHandlerType<>(BackpackScreenHandler::new, null));
+        VOID_PACK_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("void_pack"), new ScreenHandlerType<>(VoidpackScreenHandler::new, null));
+        PORTABLE_CRAFTING_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, createID("portable_crafting"), new ScreenHandlerType<>(PortableCraftingScreenHandler::new, null));
 
         Registry.register(Registries.ITEM, createID("backpack"), BACKPACK);
         Registry.register(Registries.ITEM, createID("void_pack"), VOID_PACK);

--- a/src/main/java/com/kwpugh/simple_backpack/backpack/NewBackpackScreenHandler.java
+++ b/src/main/java/com/kwpugh/simple_backpack/backpack/NewBackpackScreenHandler.java
@@ -154,8 +154,8 @@ public class NewBackpackScreenHandler extends ScreenHandler
         return itemStack;
     }
 
-    public void close(PlayerEntity player) {
-        super.close(player);
+    public void onClosed(PlayerEntity player) {
+        super.onClosed(player);
         this.inventory.onClose(player);
     }
 

--- a/src/main/java/com/kwpugh/simple_backpack/portable/PortableCraftingScreen.java
+++ b/src/main/java/com/kwpugh/simple_backpack/portable/PortableCraftingScreen.java
@@ -39,7 +39,7 @@ public class PortableCraftingScreen extends HandledScreen<PortableCraftingScreen
         this.addDrawableChild(new TexturedButtonWidget(this.x + 5, this.height / 2 - 49, 20, 18, 0, 0, 19, RECIPE_BUTTON_TEXTURE, (button) -> {
             this.recipeBook.toggleOpen();
             this.x = this.recipeBook.findLeftEdge(this.width, this.backgroundWidth);
-            ((TexturedButtonWidget)button).setPos(this.x + 5, this.height / 2 - 49);
+            ((TexturedButtonWidget)button).setPosition(this.x + 5, this.height / 2 - 49);
         }));
         this.addSelectableChild(this.recipeBook);
         this.setInitialFocus(this.recipeBook);

--- a/src/main/java/com/kwpugh/simple_backpack/portable/PortableCraftingScreenHandler.java
+++ b/src/main/java/com/kwpugh/simple_backpack/portable/PortableCraftingScreenHandler.java
@@ -16,6 +16,7 @@ import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeMatcher;
 import net.minecraft.recipe.RecipeType;
 import net.minecraft.recipe.book.RecipeBookCategory;
+import net.minecraft.registry.DynamicRegistryManager;
 import net.minecraft.screen.*;
 import net.minecraft.screen.slot.CraftingResultSlot;
 import net.minecraft.screen.slot.Slot;
@@ -74,12 +75,13 @@ public class PortableCraftingScreenHandler extends AbstractRecipeScreenHandler<C
     protected static void updateResult(ScreenHandler handler, World world, PlayerEntity player, CraftingInventory craftingInventory, CraftingResultInventory resultInventory) {
         if (!world.isClient) {
             ServerPlayerEntity serverPlayerEntity = (ServerPlayerEntity)player;
+            DynamicRegistryManager dynamicRegistryManager = DynamicRegistryManager.EMPTY;
             ItemStack itemStack = ItemStack.EMPTY;
             Optional<CraftingRecipe> optional = world.getServer().getRecipeManager().getFirstMatch(RecipeType.CRAFTING, craftingInventory, world);
             if (optional.isPresent()) {
                 CraftingRecipe craftingRecipe = (CraftingRecipe)optional.get();
                 if (resultInventory.shouldCraftRecipe(world, serverPlayerEntity, craftingRecipe)) {
-                    itemStack = craftingRecipe.craft(craftingInventory);
+                    itemStack = craftingRecipe.craft(craftingInventory, dynamicRegistryManager);
                 }
             }
 
@@ -108,8 +110,8 @@ public class PortableCraftingScreenHandler extends AbstractRecipeScreenHandler<C
         return recipe.matches(this.input, this.player.world);
     }
 
-    public void close(PlayerEntity player) {
-        super.close(player);
+    public void onClosed(PlayerEntity player) {
+        super.onClosed(player);
         this.context.run((world, pos) -> {
             this.dropInventory(player, this.input);
         });

--- a/src/main/java/com/kwpugh/simple_backpack/util/SimpleBackpackGroup.java
+++ b/src/main/java/com/kwpugh/simple_backpack/util/SimpleBackpackGroup.java
@@ -15,7 +15,7 @@ public class SimpleBackpackGroup
 
     private static final ItemGroup SIMPLE_BACKUP_GROUP = FabricItemGroup.builder(new Identifier(Backpack.MOD_ID, "simple_backpack_group"))
             .icon(() -> new ItemStack(Backpack.BACKPACK))
-            .entries((enabledFeatures, entries, operatorEnabled) -> {
+            .entries((enabledFeatures, entries) -> {
                 entries.add(Backpack.BACKPACK);
                 entries.add(Backpack.VOID_PACK);
                 entries.add(Backpack.ENDER_PACK);

--- a/src/main/java/com/kwpugh/simple_backpack/voidpack/NewVoidpackScreenHandler.java
+++ b/src/main/java/com/kwpugh/simple_backpack/voidpack/NewVoidpackScreenHandler.java
@@ -154,8 +154,8 @@ public class NewVoidpackScreenHandler extends ScreenHandler
         return itemStack;
     }
 
-    public void close(PlayerEntity player) {
-        super.close(player);
+    public void onClosed(PlayerEntity player) {
+        super.onClosed(player);
         this.inventory.onClose(player);
     }
 

--- a/src/main/java/com/kwpugh/simple_backpack/voidpack/VoidpackScreenHandler.java
+++ b/src/main/java/com/kwpugh/simple_backpack/voidpack/VoidpackScreenHandler.java
@@ -148,9 +148,9 @@ public class VoidpackScreenHandler extends GenericContainerScreenHandler
     }
 
     @Override
-    public void close(PlayerEntity player)
+    public void onClosed(PlayerEntity player)
     {
-        super.close(player);
+        super.onClosed(player);
         this.inventory.onClose(player);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,7 +5,8 @@
   "name": "SimpleBackpack",
   "description": "A simple backpack mod!",
   "authors": [
-    "kwpugh"
+    "kwpugh",
+    "sinclo"
   ],
   "contributors": [],
   "contact": {
@@ -13,7 +14,7 @@
     "sources": ""
   },
   "license": "MIT",
-  "icon": "assets/simple_backpack/textures/items/backpack.png",
+  "icon": "assets/simple_backpack/textures/item/backpack.png",
   "environment": "*",
   "entrypoints": {
     "main": [
@@ -28,8 +29,8 @@
     "simple_backpack.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.10",
-    "fabric": "*",
+    "fabricloader": ">=0.14.21",
+    "fabric-api": "*",
     "java": ">=17",
     "minecraft": "1.19.x"
   }

--- a/src/main/resources/simple_backpack.mixins.json
+++ b/src/main/resources/simple_backpack.mixins.json
@@ -2,11 +2,12 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.kwpugh.simple_backpack.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "EnchantmentTargetMixin"
   ],
   "client": [],
+  "server": [],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
### Summary

- Made appropriate updates to the simplebackpack mod, to allow this mod to be compatible with Minecraft version 1.19.4
- Fixed (what looked like) an incorrect path to the `icon` field, within `src/main/resources/fabric.mod.json`
- Tested the changes both on the client and server

### Risk/Warning:

- To be completely honest, this is my first time testing and updating a Minecraft Fabric mod.  However, I do code for a living (I am a Software QA Manager who regularly creates and manages test automation at my company.  However, I am working to improve more on software development as well).  So due to my experience, I knew enough to get the mod working for this version.
-  I targeted branch`1.19.3-rc1` in the base repository, but only because I did not have permissions to create a `1.19.4` branch in the base repository.  If this were to be merged in the main branch, I would imagine that we would want to create a 1.19.4 branch in the base repo first, then change target branches on this PR before merging

### Conclusion:

- I hope you will take time to code review this if you have time.  I am totally open to feedback on ways to improve this mod.
- Additionally, I hope to have this mod published as well, with your permission of course

Thanks in advance!